### PR TITLE
Fix: prevent undefined entry in getFHECounterByChainId

### DIFF
--- a/packages/site/hooks/useFHECounter.tsx
+++ b/packages/site/hooks/useFHECounter.tsx
@@ -64,7 +64,7 @@ function getFHECounterByChainId(
   const entry =
     FHECounterAddresses[chainId.toString() as keyof typeof FHECounterAddresses];
 
-  if (!("address" in entry) || entry.address === ethers.ZeroAddress) {
+  if (!entry || !("address" in entry) || entry.address === ethers.ZeroAddress) {
     return { abi: FHECounterABI.abi, chainId };
   }
 


### PR DESCRIPTION
## Summary
This PR fixes a potential runtime error in `getFHECounterByChainId` inside `useFHECounter.tsx`.

Previously, the code checked for `"address" in entry` without verifying whether `entry` was defined.  
If `FHECounterAddresses[chainId]` returned `undefined`, it would throw: ``` TypeError: Cannot use 'in' operator to search for 'address' in undefined ```

## Changes
- Updated the condition to safely check `entry?.address` before accessing it.  
- Prevents crashes when `entry` is `undefined` (e.g., when a chainId is not in `FHECounterAddresses`).  

**Before:**
```ts
if (!("address" in entry) || entry.address === ethers.ZeroAddress) {
  return { abi: FHECounterABI.abi, chainId };
}
```
**After:**
```ts
if (!entry?.address || entry.address === ethers.ZeroAddress) {
  return { abi: FHECounterABI.abi, chainId };
}
```

