### PR TITLE
docs: fix prerequisites heading typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ FHEVM (Fully Homomorphic Encryption Virtual Machine) enables computation on encr
 - **🌐 Multi-Network Support**: Works on both Sepolia testnet and local Hardhat node
 - **📦 Monorepo Structure**: Organized packages for SDK, contracts, and frontend
 
-## 📋 Prerequinextjss
+## 📋 Prerequisites
 
 Before you begin, ensure you have:
 


### PR DESCRIPTION
- Fix a typo in the prerequisites section title in README.md.
- No code or configuration changes.
