### PR TITLE
Enable noUnusedLocals in FHEVM React template tsconfig

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,6 +5,7 @@
     "moduleResolution": "node",
     "lib": ["ES2022"],
     "types": ["node"],
+    "noUnusedLocals": true,
     "esModuleInterop": true,
     "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true,


### PR DESCRIPTION
Enable the noUnusedLocals TypeScript option in tsconfig.json.

Help keep the template free of unused variables and imports during development.